### PR TITLE
feat: support "server-info" OOB request

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -13,16 +13,18 @@ type Config struct {
 	Web         struct {
 		Port int `yaml:"port"`
 	} `yaml:"web"`
-	Proxy struct {
-		Port   int    `yaml:"port"`
-		Scheme string `yaml:"scheme"`
-		Domain string `yaml:"domain"`
-	} `yaml:"proxy"`
-	SSHD struct {
+	Proxy Proxy `yaml:"proxy"`
+	SSHD  struct {
 		Port int `yaml:"port"`
 	} `yaml:"sshd"`
 	Database         *Database         `yaml:"database"`
 	IdentityProvider *IdentityProvider `yaml:"identity_provider"`
+}
+
+type Proxy struct {
+	Port   int    `yaml:"port"`
+	Scheme string `yaml:"scheme"`
+	Domain string `yaml:"domain"`
 }
 
 type Database struct {


### PR DESCRIPTION
## Describe the pull request

Support "server-info" OOB request, currently only contains the host URL which could be printed to the client console.

## Consent

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledged the [Contributing guide](https://github.com/pgrok/pgrok/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code or have provided the test plan.

## Test plan

<img width="943" alt="CleanShot 2023-03-25 at 22 18 54@2x" src="https://user-images.githubusercontent.com/2946214/227722829-1dbe72d7-4322-4494-b55f-227fd4979e3d.png">

