### PR TITLE
fix database connections with unix sockets

### DIFF
--- a/cmd/pgrokd/main.go
+++ b/cmd/pgrokd/main.go
@@ -106,17 +106,30 @@ func startWebServer(config *conf.Config, db *database.DB) {
 	f.Use(flamego.Logger())
 	f.Use(flamego.Recovery())
 	f.Use(flamego.Renderer())
+	var postgresUri string
+	// Check if the host is a unix domain socket
+	if strings.HasPrefix(config.Database.Host, "/") {
+		postgresUri = fmt.Sprintf("postgres://%s:%s@localhost:%d/%s?host=%s",
+			config.Database.User,
+			config.Database.Password,
+			config.Database.Port,
+			config.Database.Database,
+			config.Database.Host,
+		)
+	} else {
+		postgresUri = fmt.Sprintf("postgres://%s:%s@%s:%d/%s",
+			config.Database.User,
+			config.Database.Password,
+			config.Database.Host,
+			config.Database.Port,
+			config.Database.Database,
+		)
+	}
 	f.Use(session.Sessioner(
 		session.Options{
 			Initer: postgres.Initer(),
 			Config: postgres.Config{
-				DSN: fmt.Sprintf("postgres://%s:%s@%s:%d/%s",
-					config.Database.User,
-					config.Database.Password,
-					config.Database.Host,
-					config.Database.Port,
-					config.Database.Database,
-				),
+				DSN:       postgresUri,
 				Table:     "sessions",
 				InitTable: true,
 			},

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -52,7 +52,7 @@ func New(logWriter io.Writer, config *conf.Database) (*DB, error) {
 	)
 
 	dsn := fmt.Sprintf(
-		"user='%s' password='%s' host='%s' port='%d' dbname='%s' search_path='public' application_name='pgrokd'",
+		"user='%s' password='%s' host='%s' port='%d' dbname='%s' search_path='public' application_name='pgrokd' client_encoding=UTF8",
 		config.User, config.Password, config.Host, config.Port, config.Database,
 	)
 	db, err := gorm.Open(


### PR DESCRIPTION
## Describe the pull request

Makes it possible to connect to Postgres via a Unix Domain Socket rather than via TCP/IP.

Link to the issue: https://github.com/pgrok/pgrok/issues/72

## Consent

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledged the [Contributing guide](https://github.com/pgrok/pgrok/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code or have provided the test plan.

## Test plan

1. Configure local postgres database (tested on a debian vm, probably need to mount socket when using docker)
Make sure to replace "marie" with your unix username, otherwise this will fail.
```sql
CREATE USER marie WITH PASSWORD 'test' CREATEROLE CREATEDB LOGIN;
CREATE DATABASE pgrok WITH OWNER marie;
```

2. Start pgrokd with unix socket connection
```yaml
# ...
# take the rest from the example file
database:
  host: "/var/run/postgresql"
  port: 5432
  user: "marie"
  database: "pgrok"
```

3. Start pgrokd with tcp/ip connection
```yaml
# ...
# take the rest from the example file
database:
  host: "localhost"
  port: 5432
  user: "marie"
  password: "test"
  database: "pgrok"
```

4. Both connections should successfully connect to the database.