### PR TITLE
init webhook work

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -10,6 +10,7 @@ import (
 
 type Config struct {
 	ExternalURL string `yaml:"external_url"`
+	WebhookURL  string `yaml:"webhook_url"`
 	Web         struct {
 		Port int `yaml:"port"`
 	} `yaml:"web"`

--- a/pgrokd.exmaple.yml
+++ b/pgrokd.exmaple.yml
@@ -1,6 +1,9 @@
 # The external facing URL what will appear in the browser address bar.
 external_url: "http://localhost:3320"
 
+# A webhook which will be sent once a user is authenticated. (keep empty to disable)
+#webhook_url: "http://localhost:3000/webhook"
+
 # Settings for the web server.
 web:
   # The listening port of the web server.

--- a/pgrokd/cli/web_server.go
+++ b/pgrokd/cli/web_server.go
@@ -235,7 +235,13 @@ func startWebServer(config *conf.Config, db *database.DB) {
 				r.PlainText(http.StatusInternalServerError, fmt.Sprintf("Failed to upsert principle: %v", err))
 				return
 			}
-
+			if len(config.WebhookURL)>0 {
+				err = userutil.SendWebhook(map[string]any{"identifier": userInfo.Identifier, "display_name": userInfo.DisplayName, "subdomain": subdomain}, config.WebhookURL)
+				if err != nil {
+					r.PlainText(http.StatusInternalServerError, fmt.Sprintf("Failed to send webhook: %v", err))
+					return
+				}
+			}
 			s.Set("userID", principle.ID)
 			c.Redirect("/")
 		})


### PR DESCRIPTION
## Describe the pull request

### General
Once a user successfully logged in, a simple webhook is sent including the subdomain. If no webhook url is given, this functionally is ignored.

### Background
As I am not able to use wildcard certificates or DNS challenge for my reverse proxy (traefik), I created a simple webhook function, which sends a post internally to some small [middleware api service](https://github.com/maltegrosse/traefik-static-file-api), which handles then dynamically the https cert creation by adding routes using the subdomain name. multiple webhooks (for the same subdomain) are ignored by my middleware. 

If needed I can also provide some example setup (docker-compose) of my traefik setup.

## Consent

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledged the [Contributing guide](https://github.com/pgrok/pgrok/blob/main/.github/contributing.md).
- [ ] I have added test cases to cover the new code or have provided the test plan.

## Test plan

I havent added any test plans caus my limited golang knowledge - I hope someone else can assist here.
