### PR TITLE
Support user-supplied subdomains

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Copy, paste, and run is the best UX for everyone.
 
 Before you get started, make sure you have the following:
 
-1. A domain name (e.g. `example.com`, this will be used as the example throughout this section).
-1. A server (dedicated server, VPS) with a public IP address (e.g. `111.33.5.14`).
-1. An SSO provider (e.g. Google, JumpCloud, Okta, GitLab, Keycloak) that allows you to create OIDC clients.
+1. A domain name (e.g., `example.com`, this will be used as the example throughout this section).
+1. A server (dedicated server, VPS) with a public IP address (e.g., `111.33.5.14`).
+1. An SSO provider (e.g., Google, JumpCloud, Okta, GitLab, Keycloak) that allows you to create OIDC clients.
 1. A PostgreSQL server (Render, Vercel, Cloud SQL, self-host).
 
 > [!NOTE]
@@ -59,7 +59,7 @@ Before you get started, make sure you have the following:
 
 ### Set up the client (`pgrok`)
 
-1. Go to http://example.com, authenticate with your SSO to obtain the token and URL (e.g. `http://unknwon.example.com`).
+1. Go to http://example.com, authenticate with your SSO to obtain the token and URL (e.g., `http://unknwon.example.com`).
 1. Download the latest version of the `pgrok`:
     - For Homebrew:
         ```sh
@@ -84,7 +84,7 @@ Before you get started, make sure you have the following:
         ```
 1. Now visit the URL.
 
-As a special case, the first argument of the `pgrok http` can be used to specify forward address, e.g.
+As a special case, the first argument of the `pgrok http` can be used to specify forward address, e.g.,
 
 ```
 pgrok http 8080
@@ -149,7 +149,7 @@ This goes live at `http://staging-unknwon.example.com`, forwarding to `http://lo
 
 Because the standard SSH protocol is used for tunneling, you may well just use the vanilla SSH client.
 
-1. Go to http://example.com, authenticate with your SSO to obtain the token and URL (e.g. `http://unknwon.example.com`).
+1. Go to http://example.com, authenticate with your SSO to obtain the token and URL (e.g., `http://unknwon.example.com`).
 1. Launch the client by executing the `ssh -N -R 0::3000 example.com -p 2222` command:
     1. Enter the token as your password.
     1. Use the `-v` flag to turn on debug logging.

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ This goes live at `http://staging-unknwon.example.com`, forwarding to `http://lo
 
 - The value may contain lowercase letters, digits, and hyphens, with no leading or trailing hyphen. It shares the leftmost DNS label with your subdomain (`<prefix>-<subdomain>`), so the combined length must stay within 63 characters. Invalid values are rejected by the server.
 - The resulting URL is deterministic: if the prefixed host is already in use, the client fails with an error instead of falling back to a randomized one.
-- This flag only applies to HTTP tunnels; it has no effect on `pgrok tcp`.
+- This flag only applies to HTTP tunnels. It has no effect on `pgrok tcp`.
 
 > [!NOTE]
 > The prefix becomes part of the same subdomain label (it is joined with a hyphen, not a dot), so it is still covered by the `*.example.com` wildcard DNS record and TLS certificate set up for the server.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ pgrok http --subdomain staging 3000
 
 This goes live at `http://staging-unknwon.example.com`, forwarding to `http://localhost:3000`.
 
-- The value must be a valid DNS label: lowercase letters, digits, and hyphens, 1-63 characters, and no leading or trailing hyphen. Invalid values are rejected by the server.
+- The value may contain lowercase letters, digits, and hyphens, with no leading or trailing hyphen. It shares the leftmost DNS label with your subdomain (`<prefix>-<subdomain>`), so the combined length must stay within 63 characters. Invalid values are rejected by the server.
 - The resulting URL is deterministic: if the prefixed host is already in use, the client fails with an error instead of falling back to a randomized one.
 - This flag only applies to HTTP tunnels; it has no effect on `pgrok tcp`.
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,23 @@ dynamic_forwards: |
 
 Then all requests prefixed with the path `/api` and `/hook` will be forwarded to `http://localhost:8080` and all the rest are forwarded to the `forward_addr` (`http://localhost:3000`).
 
+#### Custom subdomain prefix
+
+By default, each user gets a single stable subdomain (e.g. `unknwon.example.com`). Use the `--uuid, -u` flag of the `http` subcommand to prepend a custom prefix to your subdomain, so you can run multiple tunnels under predictable URLs:
+
+```
+pgrok http --uuid staging 3000
+```
+
+This goes live at `http://staging-unknwon.example.com`, forwarding to `http://localhost:3000`.
+
+- The prefix must be a valid DNS label: lowercase letters, digits, and hyphens, 1-63 characters, and no leading or trailing hyphen. Invalid values are rejected by the server.
+- The resulting URL is deterministic: if the prefixed subdomain is already in use, the client fails with an error instead of falling back to a randomized one.
+- This flag only applies to HTTP tunnels; it has no effect on `pgrok tcp`.
+
+> [!NOTE]
+> The prefix becomes part of the same subdomain label (it is joined with a hyphen, not a dot), so it is still covered by the `*.example.com` wildcard DNS record and TLS certificate set up for the server.
+
 ### Vanilla SSH
 
 Because the standard SSH protocol is used for tunneling, you may well just use the vanilla SSH client.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Then all requests prefixed with the path `/api` and `/hook` will be forwarded to
 
 #### Custom subdomain prefix
 
-By default, each user gets a single stable subdomain (e.g. `unknwon.example.com`), and when it is already taken `pgrok` falls back to a host prefixed with a server-generated UUID (e.g. `7fa4f0d0...-unknwon.example.com`). Use the `--subdomain, -s` flag of the `http` subcommand to choose that prefix yourself, so you get a deterministic URL and can run multiple tunnels under predictable hosts:
+By default, each user gets a single stable subdomain (e.g., `unknwon.example.com`), and when it is already taken `pgrok` falls back to a host prefixed with a server-generated UUID (e.g., `7fa4f0d0...-unknwon.example.com`). Use the `--subdomain, -s` flag of the `http` subcommand to choose that prefix yourself, so you get a deterministic URL and can run multiple tunnels under predictable hosts:
 
 ```
 pgrok http --subdomain staging 3000
@@ -144,9 +144,6 @@ This goes live at `http://staging-unknwon.example.com`, forwarding to `http://lo
 - The value may contain lowercase letters, digits, and hyphens, with no leading or trailing hyphen. It shares the leftmost DNS label with your subdomain (`<prefix>-<subdomain>`), so the combined length must stay within 63 characters. Invalid values are rejected by the server.
 - The resulting URL is deterministic: if the prefixed host is already in use, the client fails with an error instead of falling back to a randomized one.
 - This flag only applies to HTTP tunnels. It has no effect on `pgrok tcp`.
-
-> [!NOTE]
-> The prefix becomes part of the same subdomain label (it is joined with a hyphen, not a dot), so it is still covered by the `*.example.com` wildcard DNS record and TLS certificate set up for the server.
 
 ### Vanilla SSH
 

--- a/README.md
+++ b/README.md
@@ -131,22 +131,22 @@ dynamic_forwards: |
 
 Then all requests prefixed with the path `/api` and `/hook` will be forwarded to `http://localhost:8080` and all the rest are forwarded to the `forward_addr` (`http://localhost:3000`).
 
-#### Custom subdomain prefix
+#### Custom UUID subdomain
 
-By default, each user gets a single stable subdomain (e.g. `unknwon.example.com`). Use the `--uuid, -u` flag of the `http` subcommand to prepend a custom prefix to your subdomain, so you can run multiple tunnels under predictable URLs:
+By default, each user gets a single stable subdomain (e.g. `unknwon.example.com`), and when it is already taken `pgrok` falls back to a host prefixed with a server-generated UUID (e.g. `7fa4f0d0...-unknwon.example.com`). Use the `--uuid, -u` flag of the `http` subcommand to choose that UUID yourself, so you get a deterministic URL and can run multiple tunnels under predictable hosts:
 
 ```
-pgrok http --uuid staging 3000
+pgrok http --uuid 11111111-1111-1111-1111-111111111111 3000
 ```
 
-This goes live at `http://staging-unknwon.example.com`, forwarding to `http://localhost:3000`.
+This goes live at `http://11111111111111111111111111111111-unknwon.example.com`, forwarding to `http://localhost:3000`.
 
-- The prefix must be a valid DNS label: lowercase letters, digits, and hyphens, 1-63 characters, and no leading or trailing hyphen. Invalid values are rejected by the server.
-- The resulting URL is deterministic: if the prefixed subdomain is already in use, the client fails with an error instead of falling back to a randomized one.
+- The value must be a valid UUID; invalid values are rejected by the server. It is stored in its hex-encoded form (no hyphens), matching the server-generated prefix.
+- The resulting URL is deterministic: if the prefixed host is already in use, the client fails with an error instead of falling back to a randomized one.
 - This flag only applies to HTTP tunnels; it has no effect on `pgrok tcp`.
 
 > [!NOTE]
-> The prefix becomes part of the same subdomain label (it is joined with a hyphen, not a dot), so it is still covered by the `*.example.com` wildcard DNS record and TLS certificate set up for the server.
+> The UUID becomes part of the same subdomain label (it is joined with a hyphen, not a dot), so it is still covered by the `*.example.com` wildcard DNS record and TLS certificate set up for the server.
 
 ### Vanilla SSH
 

--- a/README.md
+++ b/README.md
@@ -131,22 +131,22 @@ dynamic_forwards: |
 
 Then all requests prefixed with the path `/api` and `/hook` will be forwarded to `http://localhost:8080` and all the rest are forwarded to the `forward_addr` (`http://localhost:3000`).
 
-#### Custom UUID subdomain
+#### Custom subdomain prefix
 
-By default, each user gets a single stable subdomain (e.g. `unknwon.example.com`), and when it is already taken `pgrok` falls back to a host prefixed with a server-generated UUID (e.g. `7fa4f0d0...-unknwon.example.com`). Use the `--uuid, -u` flag of the `http` subcommand to choose that UUID yourself, so you get a deterministic URL and can run multiple tunnels under predictable hosts:
+By default, each user gets a single stable subdomain (e.g. `unknwon.example.com`), and when it is already taken `pgrok` falls back to a host prefixed with a server-generated UUID (e.g. `7fa4f0d0...-unknwon.example.com`). Use the `--subdomain, -s` flag of the `http` subcommand to choose that prefix yourself, so you get a deterministic URL and can run multiple tunnels under predictable hosts:
 
 ```
-pgrok http --uuid 11111111-1111-1111-1111-111111111111 3000
+pgrok http --subdomain staging 3000
 ```
 
-This goes live at `http://11111111111111111111111111111111-unknwon.example.com`, forwarding to `http://localhost:3000`.
+This goes live at `http://staging-unknwon.example.com`, forwarding to `http://localhost:3000`.
 
-- The value must be a valid UUID; invalid values are rejected by the server. It is stored in its hex-encoded form (no hyphens), matching the server-generated prefix.
+- The value must be a valid DNS label: lowercase letters, digits, and hyphens, 1-63 characters, and no leading or trailing hyphen. Invalid values are rejected by the server.
 - The resulting URL is deterministic: if the prefixed host is already in use, the client fails with an error instead of falling back to a randomized one.
 - This flag only applies to HTTP tunnels; it has no effect on `pgrok tcp`.
 
 > [!NOTE]
-> The UUID becomes part of the same subdomain label (it is joined with a hyphen, not a dot), so it is still covered by the `*.example.com` wildcard DNS record and TLS certificate set up for the server.
+> The prefix becomes part of the same subdomain label (it is joined with a hyphen, not a dot), so it is still covered by the `*.example.com` wildcard DNS record and TLS certificate set up for the server.
 
 ### Vanilla SSH
 

--- a/integration-tests/main_test.go
+++ b/integration-tests/main_test.go
@@ -397,10 +397,12 @@ func TestCustomUuid(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, shutdownEchoServer()) })
 
-	endpoint1, shutdownPgrok1, err := setupPgrokWithSubdomain(ctx, "http", 8001, "test")
+	// The server normalizes the requested UUID to its hex-encoded form (no
+	// hyphens), matching the format of the server-generated collision prefix.
+	endpoint1, shutdownPgrok1, err := setupPgrokWithSubdomain(ctx, "http", 8001, "11111111-1111-1111-1111-111111111111")
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, shutdownPgrok1()) })
-	require.Equal(t, "test-unknwon.localhost:3000", endpoint1)
+	require.Equal(t, "11111111111111111111111111111111-unknwon.localhost:3000", endpoint1)
 
 	// A request routed via the custom-prefixed host should be forwarded.
 	body, err := run.Cmd(ctx,

--- a/integration-tests/main_test.go
+++ b/integration-tests/main_test.go
@@ -399,8 +399,16 @@ func TestCustomUuid(t *testing.T) {
 
 	endpoint1, shutdownPgrok1, err := setupPgrokWithSubdomain(ctx, "http", 8001, "test")
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, shutdownPgrok1()) })
 	require.Equal(t, "test-unknwon.localhost:3000", endpoint1)
-	require.NoError(t, shutdownPgrok1())
+
+	// A request routed via the custom-prefixed host should be forwarded.
+	body, err := run.Cmd(ctx,
+		"curl", "--silent", "--header", "Host: "+endpoint1,
+		"http://localhost:3000/echo?q=chickendinner",
+	).Run().String()
+	require.NoError(t, err)
+	require.Contains(t, body, "chickendinner")
 }
 
 func TestTCP(t *testing.T) {

--- a/integration-tests/main_test.go
+++ b/integration-tests/main_test.go
@@ -241,6 +241,10 @@ func kill(pid int) error {
 }
 
 func setupPgrok(ctx context.Context, protocol string, port int) (endpoint string, shutdown func() error, _ error) {
+	return setupPgrokWithSubdomain(ctx, protocol, port, "")
+}
+
+func setupPgrokWithSubdomain(ctx context.Context, protocol string, port int, uuid string) (endpoint string, shutdown func() error, _ error) {
 	err := run.Cmd(ctx, "go", "build", "-o", "../.bin/pgrok", "../pgrok/cli").Run().Wait()
 	if err != nil {
 		return "", nil, errors.Wrap(err, "go build")
@@ -253,6 +257,9 @@ func setupPgrok(ctx context.Context, protocol string, port int) (endpoint string
 	}
 	if protocol == "tcp" {
 		args = append(args, "--forward-addr", "localhost:9833")
+	}
+	if uuid != "" {
+		args = append(args, "--uuid", uuid)
 	}
 	if port > 0 {
 		args = append(args, strconv.Itoa(port))
@@ -381,6 +388,19 @@ func TestMultipleHTTP(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, shutdownPgrok3()) })
 	require.Equal(t, "unknwon.localhost:3000", endpoint3)
+}
+
+func TestCustomUuid(t *testing.T) {
+	ctx := context.Background()
+
+	shutdownEchoServer, err := setupEchoServer(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, shutdownEchoServer()) })
+
+	endpoint1, shutdownPgrok1, err := setupPgrokWithSubdomain(ctx, "http", 8001, "test")
+	require.NoError(t, err)
+	require.Equal(t, "test-unknwon.localhost:3000", endpoint1)
+	require.NoError(t, shutdownPgrok1())
 }
 
 func TestTCP(t *testing.T) {

--- a/integration-tests/main_test.go
+++ b/integration-tests/main_test.go
@@ -244,7 +244,7 @@ func setupPgrok(ctx context.Context, protocol string, port int) (endpoint string
 	return setupPgrokWithSubdomain(ctx, protocol, port, "")
 }
 
-func setupPgrokWithSubdomain(ctx context.Context, protocol string, port int, uuid string) (endpoint string, shutdown func() error, _ error) {
+func setupPgrokWithSubdomain(ctx context.Context, protocol string, port int, subdomain string) (endpoint string, shutdown func() error, _ error) {
 	err := run.Cmd(ctx, "go", "build", "-o", "../.bin/pgrok", "../pgrok/cli").Run().Wait()
 	if err != nil {
 		return "", nil, errors.Wrap(err, "go build")
@@ -258,8 +258,8 @@ func setupPgrokWithSubdomain(ctx context.Context, protocol string, port int, uui
 	if protocol == "tcp" {
 		args = append(args, "--forward-addr", "localhost:9833")
 	}
-	if uuid != "" {
-		args = append(args, "--uuid", uuid)
+	if subdomain != "" {
+		args = append(args, "--subdomain", subdomain)
 	}
 	if port > 0 {
 		args = append(args, strconv.Itoa(port))
@@ -390,19 +390,17 @@ func TestMultipleHTTP(t *testing.T) {
 	require.Equal(t, "unknwon.localhost:3000", endpoint3)
 }
 
-func TestCustomUuid(t *testing.T) {
+func TestCustomSubdomain(t *testing.T) {
 	ctx := context.Background()
 
 	shutdownEchoServer, err := setupEchoServer(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, shutdownEchoServer()) })
 
-	// The server normalizes the requested UUID to its hex-encoded form (no
-	// hyphens), matching the format of the server-generated collision prefix.
-	endpoint1, shutdownPgrok1, err := setupPgrokWithSubdomain(ctx, "http", 8001, "11111111-1111-1111-1111-111111111111")
+	endpoint1, shutdownPgrok1, err := setupPgrokWithSubdomain(ctx, "http", 8001, "test")
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, shutdownPgrok1()) })
-	require.Equal(t, "11111111111111111111111111111111-unknwon.localhost:3000", endpoint1)
+	require.Equal(t, "test-unknwon.localhost:3000", endpoint1)
 
 	// A request routed via the custom-prefixed host should be forwarded.
 	body, err := run.Cmd(ctx,

--- a/integration-tests/main_test.go
+++ b/integration-tests/main_test.go
@@ -404,8 +404,7 @@ func TestCustomUuid(t *testing.T) {
 
 	// A request routed via the custom-prefixed host should be forwarded.
 	body, err := run.Cmd(ctx,
-		"curl", "--silent", "--header", "Host: "+endpoint1,
-		"http://localhost:3000/echo?q=chickendinner",
+		"curl", "--silent", fmt.Sprintf("http://%s/echo?q=chickendinner", endpoint1),
 	).Run().String()
 	require.NoError(t, err)
 	require.Contains(t, body, "chickendinner")

--- a/internal/sshd/client.go
+++ b/internal/sshd/client.go
@@ -38,6 +38,7 @@ type Client struct {
 func (c *Client) handleHint(req *ssh.Request) {
 	var payload struct {
 		Protocol string `json:"protocol"`
+		Uuid     string `json:"uuid,omitempty"`
 	}
 	err := json.Unmarshal(req.Payload, &payload)
 	if err != nil {
@@ -47,6 +48,9 @@ func (c *Client) handleHint(req *ssh.Request) {
 	if payload.Protocol != "tcp" && payload.Protocol != "http" {
 		_ = req.Reply(false, []byte("unsupported protocol: "+payload.Protocol))
 		return
+	}
+	if payload.Uuid != "" {
+		c.host = payload.Uuid + "-" + c.host
 	}
 	c.protocol = payload.Protocol
 	_ = req.Reply(true, nil)

--- a/internal/sshd/client.go
+++ b/internal/sshd/client.go
@@ -43,7 +43,7 @@ type Client struct {
 // leftmost DNS label with the principal's existing subdomain.
 var subdomainPrefixCharsRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
 
-// dnsLabelMaxLen is the maximum length of a single DNS label (RFC 1123).
+// dnsLabelMaxLen is the maximum length of a single DNS label (RFC 1035).
 const dnsLabelMaxLen = 63
 
 func (c *Client) handleHint(req *ssh.Request) {

--- a/internal/sshd/client.go
+++ b/internal/sshd/client.go
@@ -37,10 +37,14 @@ type Client struct {
 	signalReady context.CancelCauseFunc
 }
 
-// subdomainLabelRe matches a single valid DNS label as defined by RFC 1123:
-// 1 to 63 characters of lowercase letters, digits, or hyphens, not starting or
-// ending with a hyphen.
-var subdomainLabelRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
+// subdomainPrefixCharsRe matches the allowed characters for a custom subdomain
+// prefix: lowercase letters, digits, and hyphens, not starting or ending with a
+// hyphen. The overall length is bounded separately because the prefix shares the
+// leftmost DNS label with the principal's existing subdomain.
+var subdomainPrefixCharsRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+
+// dnsLabelMaxLen is the maximum length of a single DNS label (RFC 1123).
+const dnsLabelMaxLen = 63
 
 func (c *Client) handleHint(req *ssh.Request) {
 	var payload struct {
@@ -57,16 +61,24 @@ func (c *Client) handleHint(req *ssh.Request) {
 		return
 	}
 	// The client may request a custom subdomain prefix to get a deterministic
-	// host. It is only meaningful for HTTP tunnels, and it is prepended directly
-	// to the routing host, so it must be a valid DNS label to avoid producing
-	// malformed hostnames.
+	// host. It is only meaningful for HTTP tunnels, and it is prepended to the
+	// principal's subdomain within the same leftmost DNS label, so the combined
+	// label must be a valid DNS label to avoid producing malformed hostnames.
 	if payload.Subdomain != "" {
 		if payload.Protocol != "http" {
 			_ = req.Reply(false, []byte("custom subdomain is only supported for http"))
 			return
 		}
-		if !subdomainLabelRe.MatchString(payload.Subdomain) {
-			_ = req.Reply(false, []byte("invalid subdomain: must be a valid DNS label (lowercase letters, digits, and hyphens; 1-63 chars; no leading or trailing hyphen)"))
+		if !subdomainPrefixCharsRe.MatchString(payload.Subdomain) {
+			_ = req.Reply(false, []byte("invalid subdomain: must contain only lowercase letters, digits, and hyphens, with no leading or trailing hyphen"))
+			return
+		}
+		// The prefix and the existing subdomain together form the leftmost label
+		// (e.g. "staging-unknwon" in "staging-unknwon.example.com"), which must
+		// not exceed the DNS label length limit.
+		existingLabel, _, _ := strings.Cut(c.host, ".")
+		if len(payload.Subdomain)+1+len(existingLabel) > dnsLabelMaxLen {
+			_ = req.Reply(false, []byte(fmt.Sprintf("subdomain prefix is too long: at most %d characters allowed for this account", dnsLabelMaxLen-1-len(existingLabel))))
 			return
 		}
 		c.host = payload.Subdomain + "-" + c.host

--- a/internal/sshd/client.go
+++ b/internal/sshd/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	mathrand "math/rand"
 	"net"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -36,10 +37,15 @@ type Client struct {
 	signalReady context.CancelCauseFunc
 }
 
+// subdomainLabelRe matches a single valid DNS label as defined by RFC 1123:
+// 1 to 63 characters of lowercase letters, digits, or hyphens, not starting or
+// ending with a hyphen.
+var subdomainLabelRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
+
 func (c *Client) handleHint(req *ssh.Request) {
 	var payload struct {
-		Protocol string `json:"protocol"`
-		UUID     string `json:"uuid,omitempty"`
+		Protocol  string `json:"protocol"`
+		Subdomain string `json:"subdomain,omitempty"`
 	}
 	err := json.Unmarshal(req.Payload, &payload)
 	if err != nil {
@@ -50,21 +56,20 @@ func (c *Client) handleHint(req *ssh.Request) {
 		_ = req.Reply(false, []byte("unsupported protocol: "+payload.Protocol))
 		return
 	}
-	// The client may request a specific UUID prefix to get a deterministic host.
-	// It is only meaningful for HTTP tunnels, and it must be a valid UUID so the
-	// prefix matches the format of the server-generated one (hex-encoded, no
-	// hyphens) and cannot collide with another principal's subdomain.
-	if payload.UUID != "" {
+	// The client may request a custom subdomain prefix to get a deterministic
+	// host. It is only meaningful for HTTP tunnels, and it is prepended directly
+	// to the routing host, so it must be a valid DNS label to avoid producing
+	// malformed hostnames.
+	if payload.Subdomain != "" {
 		if payload.Protocol != "http" {
-			_ = req.Reply(false, []byte("custom UUID is only supported for http"))
+			_ = req.Reply(false, []byte("custom subdomain is only supported for http"))
 			return
 		}
-		id, err := uuid.Parse(payload.UUID)
-		if err != nil {
-			_ = req.Reply(false, []byte("invalid UUID: "+err.Error()))
+		if !subdomainLabelRe.MatchString(payload.Subdomain) {
+			_ = req.Reply(false, []byte("invalid subdomain: must be a valid DNS label (lowercase letters, digits, and hyphens; 1-63 chars; no leading or trailing hyphen)"))
 			return
 		}
-		c.host = hex.EncodeToString(id[:]) + "-" + c.host
+		c.host = payload.Subdomain + "-" + c.host
 		c.customHost = true
 	}
 	c.protocol = payload.Protocol

--- a/internal/sshd/client.go
+++ b/internal/sshd/client.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	mathrand "math/rand"
 	"net"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -37,11 +36,6 @@ type Client struct {
 	signalReady context.CancelCauseFunc
 }
 
-// subdomainLabelRe matches a single valid DNS label as defined by RFC 1123:
-// 1 to 63 characters of lowercase letters, digits, or hyphens, not starting or
-// ending with a hyphen.
-var subdomainLabelRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
-
 func (c *Client) handleHint(req *ssh.Request) {
 	var payload struct {
 		Protocol string `json:"protocol"`
@@ -56,19 +50,21 @@ func (c *Client) handleHint(req *ssh.Request) {
 		_ = req.Reply(false, []byte("unsupported protocol: "+payload.Protocol))
 		return
 	}
-	// The custom subdomain prefix is only meaningful for HTTP tunnels, and it is
-	// prepended directly to the routing host, so it must be a valid DNS label to
-	// avoid producing malformed or unsafe hostnames.
+	// The client may request a specific UUID prefix to get a deterministic host.
+	// It is only meaningful for HTTP tunnels, and it must be a valid UUID so the
+	// prefix matches the format of the server-generated one (hex-encoded, no
+	// hyphens) and cannot collide with another principal's subdomain.
 	if payload.UUID != "" {
 		if payload.Protocol != "http" {
-			_ = req.Reply(false, []byte("custom subdomain prefix is only supported for http"))
+			_ = req.Reply(false, []byte("custom UUID is only supported for http"))
 			return
 		}
-		if !subdomainLabelRe.MatchString(payload.UUID) {
-			_ = req.Reply(false, []byte("invalid subdomain prefix: must be a valid DNS label (lowercase letters, digits, and hyphens; 1-63 chars; no leading or trailing hyphen)"))
+		id, err := uuid.Parse(payload.UUID)
+		if err != nil {
+			_ = req.Reply(false, []byte("invalid UUID: "+err.Error()))
 			return
 		}
-		c.host = payload.UUID + "-" + c.host
+		c.host = hex.EncodeToString(id[:]) + "-" + c.host
 		c.customHost = true
 	}
 	c.protocol = payload.Protocol

--- a/internal/sshd/client.go
+++ b/internal/sshd/client.go
@@ -74,7 +74,7 @@ func (c *Client) handleHint(req *ssh.Request) {
 			return
 		}
 		// The prefix and the existing subdomain together form the leftmost label
-		// (e.g. "staging-unknwon" in "staging-unknwon.example.com"), which must
+		// (e.g., "staging-unknwon" in "staging-unknwon.example.com"), which must
 		// not exceed the DNS label length limit.
 		existingLabel, _, _ := strings.Cut(c.host, ".")
 		if len(payload.Subdomain)+1+len(existingLabel) > dnsLabelMaxLen {

--- a/internal/sshd/client.go
+++ b/internal/sshd/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	mathrand "math/rand"
 	"net"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -31,14 +32,20 @@ type Client struct {
 	principal   *database.Principal
 	protocol    string
 	host        string
+	customHost  bool // whether host carries a client-requested subdomain prefix
 	ready       context.Context
 	signalReady context.CancelCauseFunc
 }
 
+// subdomainLabelRe matches a single valid DNS label as defined by RFC 1123:
+// 1 to 63 characters of lowercase letters, digits, or hyphens, not starting or
+// ending with a hyphen.
+var subdomainLabelRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
+
 func (c *Client) handleHint(req *ssh.Request) {
 	var payload struct {
 		Protocol string `json:"protocol"`
-		Uuid     string `json:"uuid,omitempty"`
+		UUID     string `json:"uuid,omitempty"`
 	}
 	err := json.Unmarshal(req.Payload, &payload)
 	if err != nil {
@@ -49,8 +56,20 @@ func (c *Client) handleHint(req *ssh.Request) {
 		_ = req.Reply(false, []byte("unsupported protocol: "+payload.Protocol))
 		return
 	}
-	if payload.Uuid != "" {
-		c.host = payload.Uuid + "-" + c.host
+	// The custom subdomain prefix is only meaningful for HTTP tunnels, and it is
+	// prepended directly to the routing host, so it must be a valid DNS label to
+	// avoid producing malformed or unsafe hostnames.
+	if payload.UUID != "" {
+		if payload.Protocol != "http" {
+			_ = req.Reply(false, []byte("custom subdomain prefix is only supported for http"))
+			return
+		}
+		if !subdomainLabelRe.MatchString(payload.UUID) {
+			_ = req.Reply(false, []byte("invalid subdomain prefix: must be a valid DNS label (lowercase letters, digits, and hyphens; 1-63 chars; no leading or trailing hyphen)"))
+			return
+		}
+		c.host = payload.UUID + "-" + c.host
+		c.customHost = true
 	}
 	c.protocol = payload.Protocol
 	_ = req.Reply(true, nil)
@@ -212,10 +231,19 @@ func (c *Client) handleTCPIPForward(
 	}
 
 	if c.protocol == "http" {
-		id := uuid.New()
-		alternative := hex.EncodeToString(id[:]) + "-" + c.host
+		// For a client-requested subdomain prefix the URL must be deterministic,
+		// so a collision is a hard error instead of silently falling back to a
+		// random alternative host.
+		alternative := c.host
+		if !c.customHost {
+			id := uuid.New()
+			alternative = hex.EncodeToString(id[:]) + "-" + c.host
+		}
 		host, err := proxies.Set(c.host, alternative, listener.Addr().String())
 		if err != nil {
+			if c.customHost {
+				err = errors.Errorf("requested subdomain %q is already in use", c.host)
+			}
 			_ = req.Reply(false, []byte(err.Error()))
 			c.logger.Error("Failed to acquire available host",
 				"remote", c.serverConn.RemoteAddr(),

--- a/pgrok/cli/http.go
+++ b/pgrok/cli/http.go
@@ -50,9 +50,9 @@ func commandHTTP(homeDir string, logger *logx.Logger) *cli.Command {
 				Aliases: []string{"t"},
 			},
 			&cli.StringFlag{
-				Name:    "uuid",
-				Usage:   "specify a UUID to use as the subdomain prefix for a deterministic tunnel URL",
-				Aliases: []string{"u"},
+				Name:    "subdomain",
+				Usage:   "specify a custom subdomain prefix for a deterministic tunnel URL",
+				Aliases: []string{"s"},
 			},
 		),
 	}
@@ -114,7 +114,7 @@ func actionHTTP(ctx context.Context, cmd *cli.Command, logger *logx.Logger) erro
 			anyx.Coalesce(cmd.String("remote-addr"), config.RemoteAddr),
 			surl.Host,
 			anyx.Coalesce(cmd.String("token"), config.Token),
-			cmd.String("uuid"),
+			cmd.String("subdomain"),
 		)
 		if err != nil {
 			if time.Now().After(cooldownAfter) {
@@ -160,7 +160,7 @@ const (
 	protocolTCP  string = "tcp"
 )
 
-func tryConnect(logger *logx.Logger, protocol, remoteAddr, forwardAddr, token, uuid string) error {
+func tryConnect(logger *logx.Logger, protocol, remoteAddr, forwardAddr, token, subdomain string) error {
 	client, err := ssh.Dial(
 		"tcp",
 		remoteAddr,
@@ -177,7 +177,7 @@ func tryConnect(logger *logx.Logger, protocol, remoteAddr, forwardAddr, token, u
 	}
 
 	// Hint the server before establishing the reverse tunnel
-	payload, err := json.Marshal(map[string]string{"protocol": protocol, "uuid": uuid})
+	payload, err := json.Marshal(map[string]string{"protocol": protocol, "subdomain": subdomain})
 	if err != nil {
 		return errors.Wrap(err, "marshal payload")
 	}

--- a/pgrok/cli/http.go
+++ b/pgrok/cli/http.go
@@ -51,7 +51,7 @@ func commandHTTP(homeDir string, logger *logx.Logger) *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:    "uuid",
-				Usage:   "specify a custom uuid(prefix) to be used in the subdomain",
+				Usage:   "specify a custom subdomain prefix to be used in the tunnel URL",
 				Aliases: []string{"u"},
 			},
 		),

--- a/pgrok/cli/http.go
+++ b/pgrok/cli/http.go
@@ -51,7 +51,7 @@ func commandHTTP(homeDir string, logger *logx.Logger) *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:    "uuid",
-				Usage:   "specify a custom subdomain prefix to be used in the tunnel URL",
+				Usage:   "specify a UUID to use as the subdomain prefix for a deterministic tunnel URL",
 				Aliases: []string{"u"},
 			},
 		),

--- a/pgrok/cli/http.go
+++ b/pgrok/cli/http.go
@@ -181,9 +181,12 @@ func tryConnect(logger *logx.Logger, protocol, remoteAddr, forwardAddr, token, u
 	if err != nil {
 		return errors.Wrap(err, "marshal payload")
 	}
-	_, _, err = client.SendRequest("hint", true, payload)
+	ok, reply, err := client.SendRequest("hint", true, payload)
 	if err != nil {
 		return errors.Wrap(err, "hint server")
+	}
+	if !ok {
+		return errors.Errorf("server rejected hint: %s", reply)
 	}
 
 	remoteListener, err := client.Listen("tcp", "127.0.0.1:0")
@@ -196,7 +199,7 @@ func tryConnect(logger *logx.Logger, protocol, remoteAddr, forwardAddr, token, u
 	var serverInfo struct {
 		HostURL string `json:"host_url"`
 	}
-	ok, reply, err := client.SendRequest("server-info", true, payload)
+	ok, reply, err = client.SendRequest("server-info", true, payload)
 	if err != nil {
 		return errors.Wrap(err, "query server info")
 	} else if !ok {

--- a/pgrok/cli/http.go
+++ b/pgrok/cli/http.go
@@ -49,6 +49,11 @@ func commandHTTP(homeDir string, logger *logx.Logger) *cli.Command {
 				Usage:   "The authentication token",
 				Aliases: []string{"t"},
 			},
+			&cli.StringFlag{
+				Name:    "uuid",
+				Usage:   "specify a custom uuid(prefix) to be used in the subdomain",
+				Aliases: []string{"u"},
+			},
 		),
 	}
 }
@@ -109,6 +114,7 @@ func actionHTTP(ctx context.Context, cmd *cli.Command, logger *logx.Logger) erro
 			anyx.Coalesce(cmd.String("remote-addr"), config.RemoteAddr),
 			surl.Host,
 			anyx.Coalesce(cmd.String("token"), config.Token),
+			cmd.String("uuid"),
 		)
 		if err != nil {
 			if time.Now().After(cooldownAfter) {
@@ -154,7 +160,7 @@ const (
 	protocolTCP  string = "tcp"
 )
 
-func tryConnect(logger *logx.Logger, protocol, remoteAddr, forwardAddr, token string) error {
+func tryConnect(logger *logx.Logger, protocol, remoteAddr, forwardAddr, token, uuid string) error {
 	client, err := ssh.Dial(
 		"tcp",
 		remoteAddr,
@@ -171,7 +177,7 @@ func tryConnect(logger *logx.Logger, protocol, remoteAddr, forwardAddr, token st
 	}
 
 	// Hint the server before establishing the reverse tunnel
-	payload, err := json.Marshal(map[string]string{"protocol": protocol})
+	payload, err := json.Marshal(map[string]string{"protocol": protocol, "uuid": uuid})
 	if err != nil {
 		return errors.Wrap(err, "marshal payload")
 	}

--- a/pgrok/cli/tcp.go
+++ b/pgrok/cli/tcp.go
@@ -90,6 +90,7 @@ func actionTCP(ctx context.Context, cmd *cli.Command, logger *logx.Logger) error
 			anyx.Coalesce(cmd.String("remote-addr"), config.RemoteAddr),
 			forwardAddr,
 			anyx.Coalesce(cmd.String("token"), config.Token),
+			"", // no uuid as tcp doesn't use it
 		)
 		if err != nil {
 			if time.Now().After(cooldownAfter) {

--- a/pgrok/cli/tcp.go
+++ b/pgrok/cli/tcp.go
@@ -90,7 +90,7 @@ func actionTCP(ctx context.Context, cmd *cli.Command, logger *logx.Logger) error
 			anyx.Coalesce(cmd.String("remote-addr"), config.RemoteAddr),
 			forwardAddr,
 			anyx.Coalesce(cmd.String("token"), config.Token),
-			"", // no subdomain as tcp doesn't use it
+			"", // No subdomain as TCP doesn't use it
 		)
 		if err != nil {
 			if time.Now().After(cooldownAfter) {

--- a/pgrok/cli/tcp.go
+++ b/pgrok/cli/tcp.go
@@ -90,7 +90,7 @@ func actionTCP(ctx context.Context, cmd *cli.Command, logger *logx.Logger) error
 			anyx.Coalesce(cmd.String("remote-addr"), config.RemoteAddr),
 			forwardAddr,
 			anyx.Coalesce(cmd.String("token"), config.Token),
-			"", // no uuid as tcp doesn't use it
+			"", // no subdomain as tcp doesn't use it
 		)
 		if err != nil {
 			if time.Now().After(cooldownAfter) {


### PR DESCRIPTION
## Describe the pull request

As discussed in #71 this is the third PR which enables user to chose the uuid which gets prepended if there is a collision. (if a user specifies a uuid it is prepended even if the original (non-prepended url) is unused)

Link to the issue: closes #71

## Consent

- [x] I agree to follow the [Code of Conduct](https://go.dev/conduct) by submitting this pull request.
- [x] I have read and acknowledged the [Contributing guide](https://github.com/pgrok/pgrok/blob/main/.github/contributing.md).
- [x] I have added test cases to cover the new code or have provided the test plan.

## Test plan

There is a new integration test which covers the testing of the feature.