### PR TITLE
fix(docker): pin webbuilder to $BUILDPLATFORM for multi-arch builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-slim@sha256:24dc26ef1e3c3690f27ebc4136c9c186c3133b25563ae4d7f0692e4d1fe5db0e AS webbuilder
+FROM --platform=$BUILDPLATFORM node:24-slim@sha256:24dc26ef1e3c3690f27ebc4136c9c186c3133b25563ae4d7f0692e4d1fe5db0e AS webbuilder
 RUN npm install --global corepack@0.31.0
 RUN corepack enable
 


### PR DESCRIPTION
The Docker workflow on main started failing after #270:

```
ERROR: failed to build: failed to solve: node:24-slim@sha256:24dc26ef…:
no match for platform in manifest: not found
```

## Root cause
`docker.yml` builds for `linux/amd64,linux/arm64,linux/arm/v7`. Node 24 dropped 32-bit ARM support, so `node:24-slim` no longer ships an `arm/v7` manifest. Previously we used `node:22-slim`, which still publishes one.

## Fix
The `webbuilder` stage produces static JS/CSS that's identical regardless of architecture. Pin it to `$BUILDPLATFORM` (the build host arch — `linux/amd64` in CI) so buildx never tries to fetch `node:24-slim` for `arm/v7`. The `binarybuilder` (golang:1.26-alpine3.23) and final `alpine:3.23` stages still build per-target-arch and both ship arm/v7 manifests.

## Test plan
- [ ] Docker workflow on PR (`buildx-pull-request`) succeeds
- [ ] Docker workflow on main after merge succeeds and pushes the multi-arch image